### PR TITLE
Fix `get_local_sample_representation`

### DIFF
--- a/src/scvi_v2/_model.py
+++ b/src/scvi_v2/_model.py
@@ -207,6 +207,7 @@ class MrVI(JaxTrainingMixin, BaseModelClass):
         vars_in = {"params": self.module.params, **self.module.state}
         rngs = self.module.rngs
 
+        # TODO: use `self.module.get_jit_inference_fn` when it supports traced values.
         def inference_fn(
             x,
             sample_index,
@@ -225,7 +226,7 @@ class MrVI(JaxTrainingMixin, BaseModelClass):
             )["z"].mean(0)
 
         @jax.jit
-        def fn(
+        def vmapped_inference_fn(
             x,
             sample_index,
             categorical_nuisance_keys,
@@ -246,7 +247,7 @@ class MrVI(JaxTrainingMixin, BaseModelClass):
             inputs = self.module._get_inference_input(
                 array_dict,
             )
-            zs = fn(
+            zs = vmapped_inference_fn(
                 x=jnp.array(inputs["x"]),
                 sample_index=jnp.array(inputs["sample_index"]),
                 categorical_nuisance_keys=jnp.array(inputs["categorical_nuisance_keys"]),

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -24,7 +24,7 @@ def test_normalnn():
     key = jax.random.PRNGKey(0)
     key, subkey = jax.random.split(key)
     x = jnp.ones((20, 10))
-    cats = jax.random.choice(subkey, 3, (20, 1))
+    cats = jax.random.choice(subkey, 3, (20,))
     normalnn = NormalNN(10, 30, 3, training=True)
     params = normalnn.init(key, x, cats)
     normalnn.apply(params, x, cats, mutable=["batch_stats"])

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -15,7 +15,9 @@ def test_mrvi():
     model.train(1, check_val_every_n_epoch=1, train_size=0.5)
     model.is_trained_ = True
     model.history
-    model.get_latent_representation()
+    assert model.get_latent_representation().shape == (adata.shape[0], 10)
+    assert model.get_latent_representation(use_mean=False, mc_samples=2).shape == (adata.shape[0], 10)
+    assert model.get_latent_representation(use_mean=False, mc_samples=1).shape == (adata.shape[0], 10)
     assert model.get_local_sample_representation().shape == (adata.shape[0], 15, 10)
     assert model.get_local_sample_representation(return_distances=True).shape == (
         adata.shape[0],


### PR DESCRIPTION
Fixes #6 

This PR fixes MrVI's reproducibility issues.

You can see below the sample-sample similarity for the positive cell-type in the symsim experiment.
![image](https://user-images.githubusercontent.com/23222597/200091698-144c06b7-5e43-4f21-b76d-6aec65c326c6.png)

I identified a bug in the computation of the sample-sample similarity matrix in the jax implementation.
I am suspecting this comes from the fact that a n_cells, n_samples input is ultimately reshaped to a n_samples, n_cells array but I am not 100% sure.

One interesting observation is that the new implementation is MILES faster than the original (97 iterations / sec vs 3 iterations per second on my device).

Here is the fixed sample-sample matrix
![image](https://user-images.githubusercontent.com/23222597/200091880-ecc5d22c-dd07-4471-a5dc-af44e96deeb7.png)


Here are a comparison of the original and new model losses
![image](https://user-images.githubusercontent.com/23222597/200091917-8ef9bd8c-b4c4-4fc1-a437-af41367cee60.png)


I also computed a correlation score between the vectorized matrix for positive cells computed between the original implementation and JAX's, and across random seeds of the Pytorch model.
![image](https://user-images.githubusercontent.com/23222597/200092071-e476b13f-6977-4585-9956-a8e93d2f58b0.png)


