### PR TITLE
Further cleanup of decoders and encoders

### DIFF
--- a/src/scvi_v2/__init__.py
+++ b/src/scvi_v2/__init__.py
@@ -3,6 +3,6 @@ from importlib.metadata import version
 from ._model import MrVI
 from ._module import MrVAE
 
-__all__ = ["MrVI", "MrVAE"]
+__all__ = ["MrVI", "MrVAE", "DecoderZX", "DecoderUZ", "EncoderXU"]
 
 __version__ = version("scvi-v2")

--- a/src/scvi_v2/_components.py
+++ b/src/scvi_v2/_components.py
@@ -9,7 +9,7 @@ from flax.linen.initializers import variance_scaling
 from ._types import NdArray
 
 
-class Dense(nn.Dense):
+class Dense(nn.DenseGeneral):
     """Jax dense layer."""
 
     def __init__(self, *args, **kwargs):

--- a/src/scvi_v2/_constants.py
+++ b/src/scvi_v2/_constants.py
@@ -3,7 +3,6 @@ from typing import NamedTuple
 
 class _MRVI_REGISTRY_KEYS_NT(NamedTuple):
     SAMPLE_KEY: str = "sample"
-    CATEGORICAL_NUISANCE_KEYS: str = "categorical_nuisance_keys"
 
 
 MRVI_REGISTRY_KEYS = _MRVI_REGISTRY_KEYS_NT()

--- a/src/scvi_v2/_model.py
+++ b/src/scvi_v2/_model.py
@@ -174,7 +174,7 @@ class MrVI(JaxTrainingMixin, BaseModelClass):
 
             u = outputs["u"]
             z = outputs["z"]
-            if use_mean is False and mc_samples > 1:
+            if use_mean is False:
                 u = u.mean(0)
                 z = z.mean(0)
             us.append(u)

--- a/src/scvi_v2/_model.py
+++ b/src/scvi_v2/_model.py
@@ -1,6 +1,6 @@
 import logging
 from copy import deepcopy
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 import jax
 import jax.numpy as jnp
@@ -8,7 +8,7 @@ import numpy as np
 from anndata import AnnData
 from scvi import REGISTRY_KEYS
 from scvi.data import AnnDataManager
-from scvi.data.fields import CategoricalJointObsField, CategoricalObsField, LayerField
+from scvi.data.fields import CategoricalObsField, LayerField
 from scvi.model.base import BaseModelClass, JaxTrainingMixin
 from sklearn.metrics import pairwise_distances
 from tqdm import tqdm
@@ -56,25 +56,14 @@ class MrVI(JaxTrainingMixin, BaseModelClass):
         **model_kwargs,
     ):
         super().__init__(adata)
-        n_cats_per_nuisance_keys = (
-            self.adata_manager.get_state_registry(MRVI_REGISTRY_KEYS.CATEGORICAL_NUISANCE_KEYS).n_cats_per_key
-            if MRVI_REGISTRY_KEYS.CATEGORICAL_NUISANCE_KEYS in self.adata_manager.data_registry
-            else []
-        )
 
         n_sample = self.summary_stats.n_sample
-        n_obs_per_sample = (
-            adata.obs.groupby(self.adata_manager.get_state_registry(MRVI_REGISTRY_KEYS.SAMPLE_KEY)["original_key"])
-            .size()
-            .loc[self.adata_manager.get_state_registry(MRVI_REGISTRY_KEYS.SAMPLE_KEY)["categorical_mapping"]]
-            .values
-        )
+        n_batch = self.summary_stats.n_batch
         self.data_splitter = None
         self.module = MrVAE(
             n_input=self.summary_stats.n_vars,
             n_sample=n_sample,
-            n_obs_per_sample=n_obs_per_sample,
-            n_cats_per_nuisance_keys=n_cats_per_nuisance_keys,
+            n_batch=n_batch,
             **model_kwargs,
         )
         self.init_params_ = self._get_init_params(locals())
@@ -89,15 +78,14 @@ class MrVI(JaxTrainingMixin, BaseModelClass):
         adata: AnnData,
         layer: Optional[str] = None,
         sample_key: Optional[str] = None,
-        categorical_nuisance_keys: Optional[List[str]] = None,
+        batch_key: Optional[str] = None,
         **kwargs,
     ):
         setup_method_args = cls._get_setup_method_args(**locals())
         anndata_fields = [
             LayerField(REGISTRY_KEYS.X_KEY, layer, is_count_data=True),
             CategoricalObsField(MRVI_REGISTRY_KEYS.SAMPLE_KEY, sample_key),
-            CategoricalObsField(REGISTRY_KEYS.LABELS_KEY, None),
-            CategoricalJointObsField(MRVI_REGISTRY_KEYS.CATEGORICAL_NUISANCE_KEYS, categorical_nuisance_keys),
+            CategoricalObsField(REGISTRY_KEYS.BATCH_KEY, batch_key),
         ]
         adata_manager = AnnDataManager(fields=anndata_fields, setup_method_args=setup_method_args)
         adata_manager.register_fields(adata, **kwargs)

--- a/src/scvi_v2/_module.py
+++ b/src/scvi_v2/_module.py
@@ -4,7 +4,6 @@ import flax.linen as nn
 import jax
 import jax.numpy as jnp
 import numpyro.distributions as dist
-from flax.linen.initializers import variance_scaling
 from scvi import REGISTRY_KEYS
 from scvi.distributions import JaxNegativeBinomialMeanDisp as NegativeBinomial
 from scvi.module.base import JaxBaseModuleClass, LossOutput, flax_configure
@@ -34,10 +33,9 @@ class _DecoderZX(nn.Module):
         h1 = Dense(self.n_out, use_bias=False, name="amat")(z)
         z_drop = nn.Dropout(self.dropout_rate)(jax.lax.stop_gradient(z), deterministic=not training)
         # cells by n_out by n_latent (n_in)
-        A_b = nn.DenseGeneral(
+        A_b = Dense(
             (self.n_out, self.n_in),
             use_bias=False,
-            kernel_init=variance_scaling(1 / 3, "fan_in", "uniform"),
             name="amat_site",
         )(nuisance_oh)
         if z_drop.ndim == 3:
@@ -62,22 +60,16 @@ class _DecoderUZ(nn.Module):
     def __call__(self, u: NdArray, sample_covariate: NdArray, training: Optional[bool] = None) -> jnp.ndarray:
         training = nn.merge_param("training", self.training, training)
         u_drop = nn.Dropout(self.dropout_rate)(jax.lax.stop_gradient(u), deterministic=not training)
-        sample_oh = jax.nn.one_hot(
-            sample_covariate.squeeze().astype(int),
-            self.n_sample,
+        sample_covariate = sample_covariate.astype(int).flatten()
+        # cells by n_latent by n_latent
+        A_s = nn.Embed(self.n_sample, self.n_latent * self.n_latent)(sample_covariate).reshape(
+            sample_covariate.shape[0], self.n_latent, self.n_latent
         )
-        # cells by n_out by n_latent
-        A_s = nn.DenseGeneral(
-            (self.n_latent, self.n_latent),
-            use_bias=False,
-            kernel_init=variance_scaling(1 / 3, "fan_in", "uniform"),
-            name="amat_sample",
-        )(sample_oh)
         if u_drop.ndim == 3:
             h2 = jnp.einsum("cgl,bcl->bcg", A_s, u_drop)
         else:
             h2 = jnp.einsum("cgl,cl->cg", A_s, u_drop)
-        h3 = Dense(self.n_latent)(sample_oh)
+        h3 = nn.Embed(self.n_sample, self.n_latent)(sample_covariate)
         delta = h2 + h3
         return u + delta
 

--- a/src/scvi_v2/_module.py
+++ b/src/scvi_v2/_module.py
@@ -4,6 +4,7 @@ import flax.linen as nn
 import jax
 import jax.numpy as jnp
 import numpyro.distributions as dist
+from flax.linen.initializers import variance_scaling
 from scvi import REGISTRY_KEYS
 from scvi.distributions import JaxNegativeBinomialMeanDisp as NegativeBinomial
 from scvi.module.base import JaxBaseModuleClass, LossOutput, flax_configure
@@ -13,16 +14,17 @@ from ._constants import MRVI_REGISTRY_KEYS
 from ._types import NdArray
 
 DEFAULT_PX_KWARGS = {"n_hidden": 32}
-DEFAULT_PZ_KWARGS = {"scaler_n_hidden": 32}
+DEFAULT_PZ_KWARGS = {}
+DEFAULT_QU_KWARGS = {}
 
 
 class _DecoderZX(nn.Module):
 
     n_in: int
     n_out: int
-    n_nuisance: int
     n_hidden: int = 128
-    activation: str = "softmax"
+    activation: str = "softplus"
+    dropout_rate: float = 0.1
     training: Optional[bool] = None
 
     def setup(self):
@@ -35,71 +37,98 @@ class _DecoderZX(nn.Module):
         else:
             raise ValueError(f"Invalid activation {self.activation}")
 
-        self.n_latent = self.n_in - self.n_nuisance
-        self.amat = Dense(self.n_out, use_bias=False)
-        self.amat_site = self.param("amat_site", jax.random.normal, (self.n_nuisance, self.n_latent, self.n_out))
-        self.offsets = self.param("zx_offsets", jax.random.normal, (self.n_nuisance, self.n_out))
-        self.dropout_ = nn.Dropout(0.1)
+        self.amat = Dense(self.n_out, use_bias=False, name="amat")
+        self.amat_site = nn.DenseGeneral(
+            (self.n_out, self.n_in),
+            use_bias=False,
+            kernel_init=variance_scaling(1 / 3, "fan_in", "uniform"),
+            name="amat_site",
+        )
+        self.offset = Dense(self.n_out)
+        self.z_dropout = nn.Dropout(self.dropout_rate)
         self.px_r = self.param("px_r", jax.random.normal, (self.n_out,))
 
-    def __call__(self, z: NdArray, size_factor: NdArray, training: Optional[bool] = None) -> NegativeBinomial:
+    def __call__(
+        self, z: NdArray, nuisance_oh: NdArray, size_factor: NdArray, training: Optional[bool] = None
+    ) -> NegativeBinomial:
         training = nn.merge_param("training", self.training, training)
-        nuisance_oh = z[..., -self.n_nuisance :]
-        z0 = z[..., : -self.n_nuisance]
-        x1 = self.amat(z0)
-
-        nuisance_ids = jnp.argmax(nuisance_oh, axis=-1)
-        As = self.amat_site[nuisance_ids]
-        z0_stop_grad = self.dropout_(jax.lax.stop_gradient(z0), deterministic=not training)[..., None]
-        x2 = (As * z0_stop_grad).sum(-2)
-        offsets = self.offsets[nuisance_ids]
-        mu = x1 + x2 + offsets
-        mu = self.activation_fn(mu)
-        mu = mu * size_factor
-        return NegativeBinomial(mean=mu, inverse_dispersion=jnp.exp(self.px_r))
+        h1 = self.amat(z)
+        z_drop = self.z_dropout(jax.lax.stop_gradient(z), deterministic=not training)
+        # cells by n_out by n_latent (n_in)
+        A_b = self.amat_site(nuisance_oh)
+        h2 = jnp.einsum("cgl,cl->cg", A_b, z_drop)
+        h3 = self.offset(nuisance_oh)
+        mu = self.activation_fn(h1 + h2 + h3)
+        return NegativeBinomial(mean=mu * size_factor, inverse_dispersion=jnp.exp(self.px_r))
 
 
 class _DecoderUZ(nn.Module):
 
     n_latent: int
-    n_sample: int
-    n_out: int
-    use_scaler: bool = False
-    scaler_n_hidden: int = 32
+    dropout_rate: float = 0.0
     training: Optional[bool] = None
 
     def setup(self):
-        self.amat_sample = self.param("amat_sample", jax.random.normal, (self.n_sample, self.n_latent, self.n_out))
-        self.offsets = self.param("uz_offsets", jax.random.normal, (self.n_sample, self.n_out))
+        self.amat_sample = nn.DenseGeneral(
+            (self.n_latent, self.n_latent),
+            use_bias=False,
+            kernel_init=variance_scaling(1 / 3, "fan_in", "uniform"),
+            name="amat_sample",
+        )
+        self.dropout_u = nn.Dropout(self.dropout_rate)
+        self.offset = Dense(self.n_latent)
 
-        self.scaler = None
-        if self.use_scaler:
-            self.scaler = nn.Sequential(
-                [
-                    Dense(self.scaler_n_hidden),
-                    nn.LayerNorm(),
-                    nn.relu,
-                    Dense(1),
-                    nn.sigmoid,
-                ]
-            )
-
-    def __call__(self, u: NdArray, sample_index: NdArray, training: Optional[bool] = None) -> jnp.ndarray:
+    def __call__(self, u: NdArray, sample_covariate: NdArray, training: Optional[bool] = None) -> jnp.ndarray:
         training = nn.merge_param("training", self.training, training)
-        sample_index_ = sample_index.squeeze().astype(int)
-        As = self.amat_sample[sample_index_]
-
-        u_stop_grad = jax.lax.stop_gradient(u)[..., None]
-        z2 = (As * u_stop_grad).sum(-2)
-        offsets = self.offsets[sample_index_]
-        delta = z2 + offsets
-        if self.scaler is not None:
-            sample_oh = jax.nn.one_hot(sample_index, self.n_sample)
-            if u.ndim != sample_oh.ndim:
-                sample_oh = jax.lax.broadcast(sample_oh, (u.shape[0],))
-            inputs = jnp.concatenate([jax.lax.stop_gradient(u), sample_oh], axis=-1)
-            delta = delta * self.scaler(inputs)
+        u_drop = self.dropout_u(jax.lax.stop_gradient(u), deterministic=not training)
+        # cells by n_out by n_latent
+        A_s = self.amat_sample(sample_covariate)
+        if u_drop.ndim == 3:
+            h2 = jnp.einsum("cgl,bcl->bcg", A_s, u_drop)
+        else:
+            h2 = jnp.einsum("cgl,cl->cg", A_s, u_drop)
+        h3 = self.offset(sample_covariate)
+        delta = h2 + h3
         return u + delta
+
+
+class _EncoderXU(nn.Module):
+
+    n_latent: int
+    n_sample: int
+    n_latent_sample: int
+    n_hidden: int
+    training: Optional[bool] = None
+
+    def setup(self):
+        self.sample_embeddings = nn.Embed(
+            self.n_sample, self.n_latent_sample, embedding_init=jax.nn.initializers.normal()
+        )
+        self.x_featurizer = nn.Sequential([Dense(self.n_hidden), nn.relu])
+        self.bnn = ConditionalBatchNorm1d(self.n_hidden, self.n_sample)
+        self.x_featurizer2 = nn.Sequential([Dense(self.n_hidden), nn.relu])
+        self.bnn2 = ConditionalBatchNorm1d(self.n_hidden, self.n_sample)
+        self.qu = NormalDistOutputNN(self.n_hidden + self.n_latent_sample, self.n_latent)
+
+    def __call__(
+        self, x: NdArray, sample_covariate: NdArray, mc_samples: int = 1, training: Optional[bool] = None
+    ) -> dist.Normal:
+        training = nn.merge_param("training", self.training, training)
+        x_ = jnp.log1p(x)
+        zsample = self.sample_embeddings(sample_covariate.squeeze(-1).astype(int))
+        zsample_ = zsample
+        if mc_samples >= 2:
+            zsample_ = jax.lax.broadcast(zsample, (mc_samples,))
+
+        x_feat = self.x_featurizer(x_)
+        x_feat = self.bnn(x_feat, sample_covariate, training=training)
+        x_feat = self.x_featurizer2(x_feat)
+        x_feat = self.bnn2(x_feat, sample_covariate, training=training)
+        if mc_samples >= 2:
+            x_feat = jax.lax.broadcast(x_feat, (mc_samples,))
+
+        inputs = jnp.concatenate([x_feat, zsample_], axis=-1)
+        return self.qu(inputs, training=training)
 
 
 @flax_configure
@@ -112,10 +141,10 @@ class MrVAE(JaxBaseModuleClass):
     n_cats_per_nuisance_keys: NdArray
     n_latent: int = 10
     n_latent_sample: int = 2
-    uz_scaler: bool = False
     encoder_n_hidden: int = 128
     px_kwargs: Optional[dict] = None
     pz_kwargs: Optional[dict] = None
+    qu_kwargs: Optional[dict] = None
     training: bool = True
 
     def setup(self):  # noqa: D102
@@ -125,34 +154,31 @@ class MrVAE(JaxBaseModuleClass):
         pz_kwargs = DEFAULT_PZ_KWARGS.copy()
         if self.pz_kwargs is not None:
             pz_kwargs.update(self.pz_kwargs)
+        qu_kwargs = DEFAULT_QU_KWARGS.copy()
+        if self.qu_kwargs is not None:
+            qu_kwargs.update(self.qu_kwargs)
 
         assert self.n_latent_sample != 0
-        self.sample_embeddings = nn.Embed(
-            self.n_sample, self.n_latent_sample, embedding_init=jax.nn.initializers.normal()
-        )
-        n_nuisance = sum(self.n_cats_per_nuisance_keys)
 
         # Generative model
         self.px = _DecoderZX(
-            self.n_latent + n_nuisance,
+            self.n_latent,
             self.n_input,
-            n_nuisance=n_nuisance,
             **px_kwargs,
         )
         self.pz = _DecoderUZ(
             self.n_latent,
-            self.n_sample,
-            self.n_latent,
-            use_scaler=self.uz_scaler,
             **pz_kwargs,
         )
 
         # Inference model
-        self.x_featurizer = nn.Sequential([Dense(self.encoder_n_hidden), nn.relu])
-        self.bnn = ConditionalBatchNorm1d(self.encoder_n_hidden, self.n_sample)
-        self.x_featurizer2 = nn.Sequential([Dense(self.encoder_n_hidden), nn.relu])
-        self.bnn2 = ConditionalBatchNorm1d(self.encoder_n_hidden, self.n_sample)
-        self.qu = NormalDistOutputNN(self.encoder_n_hidden + self.n_latent_sample, self.n_latent)
+        self.qu = _EncoderXU(
+            self.n_latent,
+            self.n_sample,
+            self.n_latent_sample,
+            self.encoder_n_hidden,
+            **qu_kwargs,
+        )
 
     @property
     def required_rngs(self):  # noqa: D102
@@ -161,19 +187,36 @@ class MrVAE(JaxBaseModuleClass):
     def _get_inference_input(self, tensors: Dict[str, NdArray]) -> Dict[str, Any]:
         x = tensors[REGISTRY_KEYS.X_KEY]
         sample_index = tensors[MRVI_REGISTRY_KEYS.SAMPLE_KEY]
-        categorical_nuisance_keys = tensors[MRVI_REGISTRY_KEYS.CATEGORICAL_NUISANCE_KEYS]
-        return {"x": x, "sample_index": sample_index, "categorical_nuisance_keys": categorical_nuisance_keys}
+        return {"x": x, "sample_index": sample_index}
 
-    def inference(self, x, sample_index, categorical_nuisance_keys, mc_samples=1, cf_sample=None, use_mean=False):
+    def inference(self, x, sample_index, mc_samples=1, cf_sample=None, use_mean=False):
         """Latent variable inference."""
-        x_ = jnp.log1p(x)
+        qu = self.qu(x, sample_index, mc_samples=mc_samples, training=self.training)
+        if use_mean:
+            u = qu.mean
+        else:
+            u_rng = self.make_rng("u")
+            u = qu.rsample(u_rng)
 
         sample_index_cf = sample_index if cf_sample is None else cf_sample
-        zsample = self.sample_embeddings(sample_index_cf.squeeze(-1).astype(int))
-        zsample_ = zsample
-        if mc_samples >= 2:
-            zsample_ = jax.lax.broadcast(zsample, (mc_samples,))
+        z = self.pz(u, sample_index_cf, training=self.training)
+        library = jnp.expand_dims(jnp.log(x.sum(1)), 1)
 
+        return {
+            "qu": qu,
+            "u": u,
+            "z": z,
+            "library": library,
+        }
+
+    def _get_generative_input(self, tensors: Dict[str, NdArray], inference_outputs: Dict[str, Any]) -> Dict[str, Any]:
+        z = inference_outputs["z"]
+        library = inference_outputs["library"]
+        categorical_nuisance_keys = tensors[MRVI_REGISTRY_KEYS.CATEGORICAL_NUISANCE_KEYS]
+        return {"z": z, "library": library, "categorical_nuisance_keys": categorical_nuisance_keys}
+
+    def generative(self, z, library, categorical_nuisance_keys):
+        """Generative model."""
         nuisance_oh = []
         for dim in range(categorical_nuisance_keys.shape[-1]):
             nuisance_oh.append(
@@ -183,51 +226,14 @@ class MrVAE(JaxBaseModuleClass):
                 )
             )
         nuisance_oh = jnp.concatenate(nuisance_oh, axis=-1)
+        if z.ndim != nuisance_oh.ndim:
+            nuisance_oh = jax.lax.broadcast(nuisance_oh, (z.shape[0],))
 
-        x_feat = self.x_featurizer(x_)
-        x_feat = self.bnn(x_feat, sample_index, training=self.training)
-        x_feat = self.x_featurizer2(x_feat)
-        x_feat = self.bnn2(x_feat, sample_index, training=self.training)
-        if x_.ndim != zsample_.ndim:
-            x_feat_ = jax.lax.broadcast(x_feat, (mc_samples,))
-            nuisance_oh = jax.lax.broadcast(nuisance_oh, (mc_samples,))
-        else:
-            x_feat_ = x_feat
-
-        inputs = jnp.concatenate([x_feat_, zsample_], axis=-1)
-        qu = self.qu(inputs, training=self.training)
-        if use_mean:
-            u = qu.loc
-        else:
-            u_rng = self.make_rng("u")
-            u = qu.rsample(u_rng)
-
-        z = self.pz(u, sample_index_cf, training=self.training)
-        library = jnp.expand_dims(jnp.log(x.sum(1)), 1)
-
-        return {
-            "qu": qu,
-            "u": u,
-            "z": z,
-            "zsample": zsample,
-            "library": library,
-            "nuisance_oh": nuisance_oh,
-        }
-
-    def _get_generative_input(self, tensors: Dict[str, NdArray], inference_outputs: Dict[str, Any]) -> Dict[str, Any]:
-        z = inference_outputs["z"]
-        library = inference_outputs["library"]
-        nuisance_oh = inference_outputs["nuisance_oh"]
-        return {"z": z, "library": library, "nuisance_oh": nuisance_oh}
-
-    def generative(self, z, library, nuisance_oh):
-        """Generative model."""
-        inputs = jnp.concatenate([z, nuisance_oh], axis=-1)
-        px = self.px(inputs, size_factor=jnp.exp(library), training=self.training)
+        px = self.px(z, nuisance_oh, size_factor=jnp.exp(library), training=self.training)
         h = px.mean / jnp.exp(library)
 
         pu = dist.Normal(0, 1)
-        return {"px": px, "pu": pu, "h": h}
+        return {"px": px, "pu": pu, "h": h, "nuisance_oh": nuisance_oh}
 
     def loss(
         self,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -7,7 +7,7 @@ from scvi_v2 import MrVI
 def test_mrvi():
     adata = synthetic_iid()
     adata.obs["sample"] = np.random.choice(15, size=adata.shape[0])
-    MrVI.setup_anndata(adata, sample_key="sample", categorical_nuisance_keys=["batch"])
+    MrVI.setup_anndata(adata, sample_key="sample", batch_key="batch")
     model = MrVI(
         adata,
         n_latent_sample=5,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14086852/201264674-a57a3f04-1b22-4268-82a6-44bee5e737a1.png)

- cleans up decoders
- creates explicit encoder
- don't use cf_sample in encoder

Note, because Dense is used to amortize the interaction matrices, it runs about 50% slower. Not sure this is worth it. Still about 2x faster than torch.