### PR TITLE
Implementation of the statistical tests

### DIFF
--- a/src/scvi_v2/__init__.py
+++ b/src/scvi_v2/__init__.py
@@ -3,6 +3,8 @@ from importlib.metadata import version
 from ._model import MrVI
 from ._module import MrVAE
 
-__all__ = ["MrVI", "MrVAE", "DecoderZX", "DecoderUZ", "EncoderXU"]
+from ._utils import permutation_test
+
+__all__ = ["MrVI", "MrVAE", "DecoderZX", "DecoderUZ", "EncoderXU", "permutation_test"]
 
 __version__ = version("scvi-v2")

--- a/src/scvi_v2/__init__.py
+++ b/src/scvi_v2/__init__.py
@@ -2,7 +2,6 @@ from importlib.metadata import version
 
 from ._model import MrVI
 from ._module import MrVAE
-
 from ._utils import permutation_test
 
 __all__ = ["MrVI", "MrVAE", "DecoderZX", "DecoderUZ", "EncoderXU", "permutation_test"]

--- a/src/scvi_v2/_model.py
+++ b/src/scvi_v2/_model.py
@@ -276,27 +276,27 @@ class MrVI(JaxTrainingMixin, BaseModelClass):
         donor_keys: list,
         adata=None,
         batch_size=256,
-        use_vmap=True,
-        n_mc_samples=200,
-        compute_pval=True,
+        use_vmap: bool = True,
+        n_mc_samples: int = 200,
+        compute_pval: bool = True,
     ):
         """Computes for each cell a statistic (effect size or p-value)
 
         Parameters
         ----------
-        donor_keys :
+        donor_keys
             List of tuples, where the first element is the sample key and
             the second element is the statistic to be computed
-        adata :
+        adata
             AnnData object to use for computing the local sample representation.
-        batch_size :
+        batch_size
             Batch size to use for computing the local sample representation.
-        use_vmap : bool, optional
+        use_vmap
             Whether to use vmap for computing the local sample representation.
             Disabling vmap can be useful if running out of memory on a GPU.
-        n_mc_samples :
+        n_mc_samples
             Number of Monte Carlo trials to use for computing the p-values (if `compute_pval` is True).
-        compute_pval :
+        compute_pval
             Whether to compute p-values or effect sizes.
         """
         adata = self.adata if adata is None else adata

--- a/src/scvi_v2/_model.py
+++ b/src/scvi_v2/_model.py
@@ -1,6 +1,6 @@
 import logging
 from copy import deepcopy
-from typing import List, Optional, Union
+from typing import List, Optional, Tuple, Union
 
 import jax
 import jax.numpy as jnp
@@ -278,7 +278,7 @@ class MrVI(JaxTrainingMixin, BaseModelClass):
 
     def compute_cell_scores(
         self,
-        donor_keys: list,
+        donor_keys: List[Tuple],
         adata=None,
         batch_size=256,
         use_vmap: bool = True,

--- a/src/scvi_v2/_model.py
+++ b/src/scvi_v2/_model.py
@@ -5,6 +5,7 @@ from typing import List, Optional, Union
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pandas as pd
 from anndata import AnnData
 from scvi import REGISTRY_KEYS
 from scvi.data import AnnDataManager
@@ -12,11 +13,10 @@ from scvi.data.fields import CategoricalObsField, LayerField, NumericalJointObsF
 from scvi.model.base import BaseModelClass, JaxTrainingMixin
 from sklearn.metrics import pairwise_distances
 from tqdm import tqdm
-import pandas as pd
 
 from ._constants import MRVI_REGISTRY_KEYS
 from ._module import MrVAE
-from ._utils import permutation_test, compute_statistic
+from ._utils import compute_statistic, permutation_test
 
 logger = logging.getLogger(__name__)
 

--- a/src/scvi_v2/_model.py
+++ b/src/scvi_v2/_model.py
@@ -313,13 +313,14 @@ class MrVI(JaxTrainingMixin, BaseModelClass):
         vars_in = {"params": self.module.params, **self.module.state}
         rngs = self.module.rngs
 
-        sample_covariates = []
+        sample_covariates_values = []
         for sample_covariate_key, sample_covariate_test in donor_keys:
             x = self.donor_info[sample_covariate_key].values
             if sample_covariate_test == "nn":
                 x = pd.Categorical(x).codes
             x = jnp.array(x)
-            sample_covariates.append(x)
+            sample_covariates_values.append(x)
+        sample_covariate_tests = [key[1] for key in donor_keys]
 
         def inference_fn(
             x,
@@ -378,7 +379,7 @@ class MrVI(JaxTrainingMixin, BaseModelClass):
             )
 
             all_pvals = []
-            for x in sample_covariates:
+            for x, sample_covariate_test in zip(sample_covariates_values, sample_covariate_tests):
                 pvals = _get_scores(dists, x, sample_covariate_test)
                 all_pvals.append(pvals)
             all_pvals = jnp.stack(all_pvals, axis=-1)

--- a/src/scvi_v2/_utils.py
+++ b/src/scvi_v2/_utils.py
@@ -38,7 +38,7 @@ def geary_c(
     return num.sum() / denom
 
 
-# @jax.jit
+@jax.jit
 def nn_statistic(
     w: jnp.ndarray,
     x: jnp.ndarray,

--- a/src/scvi_v2/_utils.py
+++ b/src/scvi_v2/_utils.py
@@ -65,7 +65,7 @@ def permutation_test(
     node_colors: Union[np.ndarray, jnp.ndarray],
     statistic: str = "geary",
     n_mc_samples: int = 1000,
-    alternative: str = "less",
+    alternative: str = "greater",
 ):
     """Permutation test for guided analyses.
 

--- a/src/scvi_v2/_utils.py
+++ b/src/scvi_v2/_utils.py
@@ -74,11 +74,11 @@ def compute_statistic(
 
     Parameters
     ----------
-    distances :
+    distances
         square distance matrix between all observations
-    node_colors :
+    node_colors
         observed covariate values for each observation
-    statistic :
+    statistic
         one of "geary" or "nn"
     """
     distances_ = jnp.array(distances)

--- a/src/scvi_v2/_utils.py
+++ b/src/scvi_v2/_utils.py
@@ -14,8 +14,10 @@ def geary_c(
 
     Parameters
     ----------
-    w : distance matrix
-    x : vector of continuous values
+    w
+        distance matrix
+    x
+        vector of continuous values
     """
 
     num = x[:, None] - x[None, :]
@@ -34,8 +36,10 @@ def nn_statistic(
 
     Parameters
     ----------
-    w : distance matrix
-    x : vector of discrete values
+    w
+        distance matrix
+    x
+        vector of discrete values
     """
     groups_mat = x[:, None] - x[None, :]
     groups_mat = (groups_mat == 0).astype(int)
@@ -71,11 +75,16 @@ def permutation_test(
 
     Parameters
     ----------
-    distances : square distance matrix between all observations
-    node_colors : observed covariate values for each observation
-    statistic : one of "geary" or "nn"
-    n_mc_samples : number of Monte Carlo samples for the permutation test
-    alternative : one of "less", "greater", to specify the alternative hypothesis
+    distances
+        square distance matrix between all observations
+    node_colors
+        observed covariate values for each observation
+    statistic
+        one of "geary" or "nn"
+    n_mc_samples
+        number of Monte Carlo samples for the permutation test
+    alternative
+        one of "less", "greater", to specify the alternative hypothesis
     """
 
     distances_ = jnp.array(distances)

--- a/src/scvi_v2/_utils.py
+++ b/src/scvi_v2/_utils.py
@@ -1,0 +1,46 @@
+import jax
+import jax.numpy as jnp
+
+
+def geary_c(w, x):
+    """Geary's C statistic.
+
+    x: array of shape (n,)
+    w: array of shape (n, n)
+    """
+
+    num = x[:, None] - x[None, :]
+    num = (num**2) * w
+    num = num / (2 * w.sum())
+    denom = x.var()
+    return num.sum() / denom
+
+
+def permutation_test(distances, node_colors, statistic="geary", n_mc_samples=1000, alternative="less"):
+    """Permutation test for guided analyses."""
+
+    distances_ = jnp.array(distances)
+    node_colors_ = jnp.array(node_colors)
+    key = jax.random.PRNGKey(0)
+
+    stat_fn = geary_c if statistic == "geary" else None
+    assert stat_fn is not None
+
+    t_obs = stat_fn(distances, node_colors)
+    t_perm = []
+
+    keys = jax.random.split(key, n_mc_samples)
+
+    def permute_compute(w, x, key):
+        x_ = jax.random.permutation(key, x)
+        return stat_fn(w, x_)
+    t_perm = jax.vmap(permute_compute, in_axes=(None, None, 0), out_axes=0)(distances_, node_colors_, keys)
+
+    if alternative == "greater":
+        cdt = t_obs > t_perm
+    elif alternative == "less":
+        cdt = t_obs < t_perm
+    else:
+        raise ValueError("alternative must be 'greater' or 'less'")
+    pval = (1.0 + cdt.sum()) / (1.0 + n_mc_samples)
+    return pval

--- a/src/scvi_v2/_utils.py
+++ b/src/scvi_v2/_utils.py
@@ -2,6 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
+@jax.jit
 def geary_c(
     w: jnp.ndarray,
     x: jnp.ndarray,
@@ -19,6 +20,7 @@ def geary_c(
     return num.sum() / denom
 
 
+@jax.jit
 def nn_statistic(
     w: jnp.ndarray,
     x: jnp.ndarray,
@@ -61,6 +63,7 @@ def permutation_test(distances, node_colors, statistic="geary", n_mc_samples=100
 
     keys = jax.random.split(key, n_mc_samples)
 
+    @jax.jit
     def permute_compute(w, x, key):
         x_ = jax.random.permutation(key, x)
         return stat_fn(w, x_)

--- a/src/scvi_v2/_utils.py
+++ b/src/scvi_v2/_utils.py
@@ -20,7 +20,7 @@ def geary_c(
     return num.sum() / denom
 
 
-@jax.jit
+# @jax.jit
 def nn_statistic(
     w: jnp.ndarray,
     x: jnp.ndarray,
@@ -30,14 +30,17 @@ def nn_statistic(
 
     processed_mat1 = groups_mat - jnp.diag(groups_mat.diagonal())
     is_diff_group_or_id = processed_mat1 == 0
+    # above matrix masks samples with different group or id, and diagonal elements
     penalties1 = jnp.zeros(w.shape)
-    penalties1 += is_diff_group_or_id * jnp.inf
+    penalties1 += is_diff_group_or_id * 1e6
     d1 = w + penalties1
     distances_to_same = d1.min(axis=1)
 
-    is_same_group = processed_mat1 > 0
+    processed_mat2 = groups_mat
+    is_same_group = processed_mat2 > 0
+    # above matrix masks samples with same group (including the diagonal)
     penalties2 = jnp.zeros(w.shape)
-    penalties2 += is_same_group * jnp.inf
+    penalties2 += is_same_group * 1e6
     d2 = w + penalties2
     distances_to_diff = d2.min(axis=1)
 

--- a/src/scvi_v2/_utils.py
+++ b/src/scvi_v2/_utils.py
@@ -2,7 +2,10 @@ import jax
 import jax.numpy as jnp
 
 
-def geary_c(w, x):
+def geary_c(
+    w: jnp.ndarray,
+    x: jnp.ndarray,
+):
     """Geary's C statistic.
 
     x: array of shape (n,)
@@ -16,6 +19,30 @@ def geary_c(w, x):
     return num.sum() / denom
 
 
+def nn_statistic(
+    w: jnp.ndarray,
+    x: jnp.ndarray,
+):
+    groups_mat = x[:, None] - x[None, :]
+    groups_mat = (groups_mat == 0).astype(int)
+
+    processed_mat1 = groups_mat - jnp.diag(groups_mat.diagonal())
+    is_diff_group_or_id = processed_mat1 == 0
+    penalties1 = jnp.zeros(w.shape)
+    penalties1 += is_diff_group_or_id * jnp.inf
+    d1 = w + penalties1
+    distances_to_same = d1.min(axis=1)
+
+    is_same_group = processed_mat1 > 0
+    penalties2 = jnp.zeros(w.shape)
+    penalties2 += is_same_group * jnp.inf
+    d2 = w + penalties2
+    distances_to_diff = d2.min(axis=1)
+
+    delta = distances_to_same - distances_to_diff
+    return delta.mean()
+
+
 def permutation_test(distances, node_colors, statistic="geary", n_mc_samples=1000, alternative="less"):
     """Permutation test for guided analyses."""
 
@@ -23,7 +50,10 @@ def permutation_test(distances, node_colors, statistic="geary", n_mc_samples=100
     node_colors_ = jnp.array(node_colors)
     key = jax.random.PRNGKey(0)
 
-    stat_fn = geary_c if statistic == "geary" else None
+    if statistic == "geary":
+        stat_fn = geary_c
+    elif statistic == "nn":
+        stat_fn = nn_statistic
     assert stat_fn is not None
 
     t_obs = stat_fn(distances, node_colors)
@@ -34,6 +64,7 @@ def permutation_test(distances, node_colors, statistic="geary", n_mc_samples=100
     def permute_compute(w, x, key):
         x_ = jax.random.permutation(key, x)
         return stat_fn(w, x_)
+
     t_perm = jax.vmap(permute_compute, in_axes=(None, None, 0), out_axes=0)(distances_, node_colors_, keys)
 
     if alternative == "greater":

--- a/src/scvi_v2/_utils.py
+++ b/src/scvi_v2/_utils.py
@@ -21,6 +21,7 @@ def geary_c(
     """
     # spatial weights are higher for closer points
     w_ = 1.0 / (w + 1e-6)
+    w_ -= jnp.diag(jnp.diag(w_))
     num = x[:, None] - x[None, :]
     num = (num**2) * w_
     num = num / (2 * w_.sum())
@@ -119,7 +120,6 @@ def permutation_test(
     random_seed
         seed used to compute random sample permutations
     """
-
     distances_ = jnp.array(distances)
     node_colors_ = jnp.array(node_colors)
     key = jax.random.PRNGKey(random_seed)

--- a/src/scvi_v2/_utils.py
+++ b/src/scvi_v2/_utils.py
@@ -65,6 +65,35 @@ def nn_statistic(
     return delta.mean()
 
 
+def compute_statistic(
+    distances: Union[np.ndarray, jnp.ndarray],
+    node_colors: Union[np.ndarray, jnp.ndarray],
+    statistic: str = "geary",
+):
+    """Computes a statistic for guided analyses.
+
+    Parameters
+    ----------
+    distances :
+        square distance matrix between all observations
+    node_colors :
+        observed covariate values for each observation
+    statistic :
+        one of "geary" or "nn"
+    """
+    distances_ = jnp.array(distances)
+    node_colors_ = jnp.array(node_colors)
+
+    if statistic == "geary":
+        stat_fn = geary_c
+    elif statistic == "nn":
+        stat_fn = nn_statistic
+    assert stat_fn is not None
+
+    t_obs = stat_fn(distances_, node_colors_)
+    return t_obs
+
+
 def permutation_test(
     distances: Union[np.ndarray, jnp.ndarray],
     node_colors: Union[np.ndarray, jnp.ndarray],
@@ -101,7 +130,7 @@ def permutation_test(
         stat_fn = nn_statistic
     assert stat_fn is not None
 
-    t_obs = stat_fn(distances, node_colors)
+    t_obs = stat_fn(distances, node_colors_)
     t_perm = []
 
     keys = jax.random.split(key, n_mc_samples)

--- a/src/scvi_v2/_utils.py
+++ b/src/scvi_v2/_utils.py
@@ -1,5 +1,8 @@
+from typing import Union
+
 import jax
 import jax.numpy as jnp
+import numpy as np
 
 
 @jax.jit
@@ -7,10 +10,12 @@ def geary_c(
     w: jnp.ndarray,
     x: jnp.ndarray,
 ):
-    """Geary's C statistic.
+    """Computes Geary's C statistic from a distance matrix and a vector of values.
 
-    x: array of shape (n,)
-    w: array of shape (n, n)
+    Parameters
+    ----------
+    w : distance matrix
+    x : vector of continuous values
     """
 
     num = x[:, None] - x[None, :]
@@ -25,6 +30,13 @@ def nn_statistic(
     w: jnp.ndarray,
     x: jnp.ndarray,
 ):
+    """Computes differences of distances to nearest neighbor from the same group and from different groups.
+
+    Parameters
+    ----------
+    w : distance matrix
+    x : vector of discrete values
+    """
     groups_mat = x[:, None] - x[None, :]
     groups_mat = (groups_mat == 0).astype(int)
 
@@ -48,8 +60,23 @@ def nn_statistic(
     return delta.mean()
 
 
-def permutation_test(distances, node_colors, statistic="geary", n_mc_samples=1000, alternative="less"):
-    """Permutation test for guided analyses."""
+def permutation_test(
+    distances: Union[np.ndarray, jnp.ndarray],
+    node_colors: Union[np.ndarray, jnp.ndarray],
+    statistic: str = "geary",
+    n_mc_samples: int = 1000,
+    alternative: str = "less",
+):
+    """Permutation test for guided analyses.
+
+    Parameters
+    ----------
+    distances : square distance matrix between all observations
+    node_colors : observed covariate values for each observation
+    statistic : one of "geary" or "nn"
+    n_mc_samples : number of Monte Carlo samples for the permutation test
+    alternative : one of "less", "greater", to specify the alternative hypothesis
+    """
 
     distances_ = jnp.array(distances)
     node_colors_ = jnp.array(node_colors)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -10,7 +10,6 @@ def test_mrvi():
     meta1 = np.random.randint(0, 2, size=15)
     adata.obs["meta1"] = meta1[adata.obs["sample"].values]
 
-
     meta2 = np.random.randn(15)
     adata.obs["meta2"] = meta2[adata.obs["sample"].values]
     MrVI.setup_anndata(adata, sample_key="sample", batch_key="batch")

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -7,6 +7,11 @@ from scvi_v2 import MrVI
 def test_mrvi():
     adata = synthetic_iid()
     adata.obs["sample"] = np.random.choice(15, size=adata.shape[0])
+    meta1 = np.random.randint(0, 2, size=15)
+    adata.obs["meta1"] = meta1[adata.obs["sample"].values]
+
+    meta2 = np.random.randn(15)
+    adata.obs["meta2"] = meta2[adata.obs["sample"].values]
     MrVI.setup_anndata(adata, sample_key="sample", batch_key="batch")
     model = MrVI(
         adata,
@@ -34,5 +39,15 @@ def test_mrvi():
     )
     assert np.allclose(local_map, local_vmap, atol=1e-6)
     assert np.allclose(local_dist_map, local_dist_vmap, atol=1e-6)
+
+    donor_keys = [
+        ("meta1", "nn"),
+        ("meta2", "geary"),
+    ]
+    pvals = model.compute_cell_scores(donor_keys=donor_keys)
+    assert pvals.shape == (adata.shape[0], 2)
+    es = model.compute_cell_scores(donor_keys=donor_keys, compute_pval=False)
+    assert es.shape == (adata.shape[0], 2)
+
     # tests __repr__
     print(model)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -5,16 +5,17 @@ from sklearn.metrics import pairwise_distances
 
 def test_geary():
     # case with spatial correlation
+    np.random.seed(0)
     pos = np.random.randn(100, 2)
     w = pairwise_distances(pos)
     x = pos[:, 0]
-    assert permutation_test(w, x) < 0.05
+    assert permutation_test(w, x, selected_tail="greater") < 0.05
 
     # case without expected
     ps = []
     for _ in range(10):
         x = np.random.randn(100)
-        p = permutation_test(w, x)
+        p = permutation_test(w, x, selected_tail="greater")
         ps.append(p)
     ps = np.array(ps)
     assert ps.max() >= 0.3
@@ -22,18 +23,19 @@ def test_geary():
 
 def test_nn():
     # case with spatial correlation
+    np.random.seed(0)
     pos = np.random.randn(100, 2)
     w = pairwise_distances(pos)
     x = pos[:, 0] >= 0
     x = x.astype(int)
-    assert permutation_test(w, x, statistic="nn", alternative="greater") < 0.05
+    assert permutation_test(w, x, statistic="nn", selected_tail="greater") < 0.05
 
     # case without expected
     ps = []
     for _ in range(10):
         x = np.random.randn(100) >= 0
         x = x.astype(int)
-        p = permutation_test(w, x, statistic="nn", alternative="greater")
+        p = permutation_test(w, x, statistic="nn", selected_tail="greater")
         ps.append(p)
     ps = np.array(ps)
     assert ps.max() >= 0.3

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scvi_v2._utils import permutation_test
+from scvi_v2._utils import permutation_test, compute_statistic
 from sklearn.metrics import pairwise_distances
 
 
@@ -9,6 +9,8 @@ def test_geary():
     pos = np.random.randn(100, 2)
     w = pairwise_distances(pos)
     x = pos[:, 0]
+
+    assert compute_statistic(w, x, statistic="geary") < 1
     assert permutation_test(w, x, selected_tail="greater") < 0.05
 
     # case without expected
@@ -28,6 +30,7 @@ def test_nn():
     w = pairwise_distances(pos)
     x = pos[:, 0] >= 0
     x = x.astype(int)
+    assert compute_statistic(w, x, statistic="nn") < 0
     assert permutation_test(w, x, statistic="nn", selected_tail="greater") < 0.05
 
     # case without expected

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -18,3 +18,22 @@ def test_geary():
         ps.append(p)
     ps = np.array(ps)
     assert ps.max() >= 0.3
+
+
+def test_nn():
+    # case with spatial correlation
+    pos = np.random.randn(100, 2)
+    w = pairwise_distances(pos)
+    x = pos[:, 0] >= 0
+    x = x.astype(int)
+    assert permutation_test(w, x, statistic="nn", alternative="greater") < 0.05
+
+    # case without expected
+    ps = []
+    for _ in range(10):
+        x = np.random.randn(100) >= 0
+        x = x.astype(int)
+        p = permutation_test(w, x, statistic="nn", alternative="greater")
+        ps.append(p)
+    ps = np.array(ps)
+    assert ps.max() >= 0.3

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,6 +1,7 @@
 import numpy as np
-from scvi_v2._utils import permutation_test, compute_statistic
 from sklearn.metrics import pairwise_distances
+
+from scvi_v2._utils import compute_statistic, permutation_test
 
 
 def test_geary():

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,20 @@
+import numpy as np
+from scvi_v2._utils import permutation_test
+from sklearn.metrics import pairwise_distances
+
+
+def test_geary():
+    # case with spatial correlation
+    pos = np.random.randn(100, 2)
+    w = pairwise_distances(pos)
+    x = pos[:, 0]
+    assert permutation_test(w, x) < 0.05
+
+    # case without expected
+    ps = []
+    for _ in range(10):
+        x = np.random.randn(100)
+        p = permutation_test(w, x)
+        ps.append(p)
+    ps = np.array(ps)
+    assert ps.max() >= 0.3

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -13,6 +13,7 @@ def test_geary():
 
     assert compute_statistic(w, x, statistic="geary") < 1
     assert permutation_test(w, x, selected_tail="greater") < 0.05
+    assert permutation_test(w, x, selected_tail="greater", use_vmap=False) < 0.05
 
     # case without expected
     ps = []
@@ -20,6 +21,9 @@ def test_geary():
         x = np.random.randn(100)
         p = permutation_test(w, x, selected_tail="greater")
         ps.append(p)
+        p_no_vmap = permutation_test(w, x, selected_tail="greater", use_vmap=False)
+        ps.append(p_no_vmap)
+
     ps = np.array(ps)
     assert ps.max() >= 0.3
 
@@ -33,6 +37,7 @@ def test_nn():
     x = x.astype(int)
     assert compute_statistic(w, x, statistic="nn") < 0
     assert permutation_test(w, x, statistic="nn", selected_tail="greater") < 0.05
+    assert permutation_test(w, x, statistic="nn", selected_tail="greater", use_vmap=False) < 0.05
 
     # case without expected
     ps = []
@@ -41,5 +46,7 @@ def test_nn():
         x = x.astype(int)
         p = permutation_test(w, x, statistic="nn", selected_tail="greater")
         ps.append(p)
+        p_no_vmap = permutation_test(w, x, statistic="nn", selected_tail="greater", use_vmap=False)
+        ps.append(p_no_vmap)
     ps = np.array(ps)
     assert ps.max() >= 0.3


### PR DESCRIPTION
Fixes #15 

A general function, called `permutation_test` is implemented for the purpose of detecting spatial correlations from sample-sample distance matrices and sample metadata.

The function can handle two cases:
1. **continuous sample covariate**: in that case, we consider Geary's C as a statistic.
2. **categorical covariate**: we focus on the difference between the smallest distance to a sample of the same category vs the smallest distance to a sample of a different category

In either case, we compare the observed data statistic to the statistic of the data after permuting the sample metadata for significance assessment.

The implementation tests suggest that the function performs as expected.

