### PR TITLE
Implement normalized distance metric and use xarray for local reps/dists

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ urls.Home-page = "https://github.com/YosefLab/scvi-v2"
 dependencies = [
     "anndata",
     "scvi-tools>=0.19.0",
-    "xarray=2022.12.0",
+    "xarray==2022.12.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,8 @@ urls.Source = "https://github.com/YosefLab/scvi-v2"
 urls.Home-page = "https://github.com/YosefLab/scvi-v2"
 dependencies = [
     "anndata",
-    "scvi-tools>=0.19.0"
+    "scvi-tools>=0.19.0",
+    "xarray=2022.12.0",
 ]
 
 [project.optional-dependencies]

--- a/src/scvi_v2/_model.py
+++ b/src/scvi_v2/_model.py
@@ -364,9 +364,10 @@ class MrVI(JaxTrainingMixin, BaseModelClass):
 
             sample_index = self.module._get_inference_input(array_dict)["sample_index"]
             A_s = apply_get_A_s(sample_index)
+            B = jnp.expand_dims(jnp.eye(A_s.shape[1]), 0) + A_s
             squared_l2_sigma = 2 * jnp.einsum(
-                "cij, cjk, clk -> cil", A_s, qu_vars_diag, A_s
-            )  # A_s @ qu_vars_diag @ A_s.T
+                "cij, cjk, clk -> cil", B, qu_vars_diag, B
+            )  # (I + A_s) @ qu_vars_diag @ (I + A_s).T
             # Resymmetrize squared_l2_sigma to avoid numerical errors
             squared_l2_sigma = (squared_l2_sigma + jnp.transpose(squared_l2_sigma, axes=(0, 2, 1))) / 2
             eigvals = jax.vmap(jnp.linalg.eig)(squared_l2_sigma)[0].astype(float)

--- a/src/scvi_v2/_model.py
+++ b/src/scvi_v2/_model.py
@@ -1,5 +1,4 @@
 import logging
-import pdb
 from copy import deepcopy
 from typing import List, Optional, Tuple, Union
 
@@ -314,7 +313,6 @@ class MrVI(JaxTrainingMixin, BaseModelClass):
             dists_data_array = np.clip(dists_data_array - local_baseline_means, a_min=0, a_max=None) / (
                 local_baseline_vars**0.5
             )
-            pdb.set_trace()
 
         return dists_data_array
 

--- a/src/scvi_v2/_model.py
+++ b/src/scvi_v2/_model.py
@@ -368,9 +368,7 @@ class MrVI(JaxTrainingMixin, BaseModelClass):
             squared_l2_sigma = 2 * jnp.einsum(
                 "cij, cjk, clk -> cil", B, qu_vars_diag, B
             )  # (I + A_s) @ qu_vars_diag @ (I + A_s).T
-            # Resymmetrize squared_l2_sigma to avoid numerical errors
-            squared_l2_sigma = (squared_l2_sigma + jnp.transpose(squared_l2_sigma, axes=(0, 2, 1))) / 2
-            eigvals = jax.vmap(jnp.linalg.eig)(squared_l2_sigma)[0].astype(float)
+            eigvals = jax.vmap(jnp.linalg.eigh)(squared_l2_sigma)[0].astype(float)
             _ = self.module.rngs  # Regenerate seed_rng
             normal_samples = jax.random.normal(
                 self.module.seed_rng, shape=(eigvals.shape[0], mc_samples, eigvals.shape[1])

--- a/src/scvi_v2/_model.py
+++ b/src/scvi_v2/_model.py
@@ -1,6 +1,7 @@
 import logging
+import pdb
 from copy import deepcopy
-from typing import List, Optional, Union
+from typing import List, Optional, Tuple, Union
 
 import jax
 import jax.numpy as jnp
@@ -193,10 +194,9 @@ class MrVI(JaxTrainingMixin, BaseModelClass):
 
     def get_local_sample_representation(
         self,
-        adata=None,
-        batch_size=256,
-        return_distances=False,
-        use_vmap=True,
+        adata: Optional[AnnData] = None,
+        batch_size: int = 256,
+        use_vmap: bool = True,
     ) -> xr.DataArray:
         """
         Computes the local sample representation of the cells in the adata object.
@@ -209,9 +209,6 @@ class MrVI(JaxTrainingMixin, BaseModelClass):
             AnnData object to use for computing the local sample representation.
         batch_size
             Batch size to use for computing the local sample representation.
-        return_distances
-            If ``return_distances`` is ``True``, returns a distance matrix of
-            size (n_sample, n_sample) for each cell.
         use_vmap
             Whether to use vmap for computing the local sample representation.
             Disabling vmap can be useful if running out of memory on a GPU.
@@ -270,6 +267,7 @@ class MrVI(JaxTrainingMixin, BaseModelClass):
                 cf_sample=jnp.array(cf_sample),
             )
             reps.append(zs)
+
         reps = np.array(jax.device_get(jnp.concatenate(reps, axis=0)))
         sample_order = self.adata_manager.get_state_registry(MRVI_REGISTRY_KEYS.SAMPLE_KEY).categorical_mapping
         reps_data_array = xr.DataArray(
@@ -279,7 +277,87 @@ class MrVI(JaxTrainingMixin, BaseModelClass):
             name="sample_representation",
         )
 
-        if return_distances:
-            return self.compute_distance_matrix_from_representations(reps_data_array)
-
         return reps_data_array
+
+    def get_local_sample_distances(
+        self,
+        adata: Optional[AnnData] = None,
+        batch_size: int = 256,
+        normalize_distances: bool = False,
+        use_vmap: bool = True,
+    ) -> xr.DataArray:
+        """
+        Computes the local sample distances of the cells in the adata object.
+
+        For each cell, it returns a matrix of size (n_sample, n_sample).
+
+        Parameters
+        ----------
+        adata
+            AnnData object to use for computing the local sample representation.
+        batch_size
+            Batch size to use for computing the local sample representation.
+        normalize_distances
+            Whether to normalize the local sample distances. Normalizes by
+            the standard deviation of the original intra-sample distances.
+        use_vmap
+            Whether to use vmap for computing the local sample representation.
+            Disabling vmap can be useful if running out of memory on a GPU.
+        """
+        reps_data_array = self.get_local_sample_representation(adata=adata, batch_size=batch_size, use_vmap=use_vmap)
+        dists_data_array = self.compute_distance_matrix_from_representations(reps_data_array)
+
+        if normalize_distances:
+            local_baseline_means, local_baseline_vars = self._compute_local_baseline_dists(adata)
+            local_baseline_means = local_baseline_means.reshape(-1, 1, 1)
+            local_baseline_vars = local_baseline_vars.reshape(-1, 1, 1)
+            dists_data_array = np.clip(dists_data_array - local_baseline_means, a_min=0, a_max=None) / (
+                local_baseline_vars**0.5
+            )
+            pdb.set_trace()
+
+        return dists_data_array
+
+    def _compute_local_baseline_dists(
+        self, adata: Optional[AnnData], mc_samples: int = 1000, batch_size: int = 256
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        adata = self.adata if adata is None else adata
+        self._check_if_trained(warn=False)
+        adata = self._validate_anndata(adata)
+        scdl = self._make_data_loader(adata=adata, indices=None, batch_size=batch_size, iter_ndarray=True)
+
+        jit_inference_fn = self.module.get_jit_inference_fn()
+
+        def get_A_s(module, sample_index):
+            A_s_embed = module.pz.get_variable("params", "A_s")["embedding"]
+            sample_index = sample_index.astype(int).flatten()
+            return jnp.take(A_s_embed, sample_index, axis=0)
+
+        def apply_get_A_s(sample_index):
+            vars_in = {"params": self.module.params, **self.module.state}
+            rngs = self.module.rngs
+            A_s = self.module.apply(vars_in, rngs=rngs, method=get_A_s, sample_index=sample_index).reshape(
+                sample_index.shape[0], self.module.n_latent, self.module.n_latent
+            )
+            return A_s
+
+        baseline_means = []
+        baseline_vars = []
+        for array_dict in tqdm(scdl):
+            qu = jit_inference_fn(self.module.rngs, array_dict)["qu"]
+            qu_vars_diag = jax.vmap(jnp.diag)(qu.variance)
+
+            sample_index = self.module._get_inference_input(array_dict)["sample_index"]
+            A_s = apply_get_A_s(sample_index)
+            squared_l2_sigma = 2 * jnp.einsum("cji, cjk, ckl -> cil", A_s, qu_vars_diag, A_s)
+            eigvals = jax.vmap(jnp.linalg.eig)(squared_l2_sigma)[0].astype(float)
+            _ = self.module.rngs  # Regenerate seed_rng
+            normal_samples = jax.random.normal(
+                self.module.seed_rng, shape=(eigvals.shape[0], mc_samples, eigvals.shape[1])
+            )
+            squared_l2_dists = jnp.sum(jnp.einsum("cij, cj -> cij", (normal_samples**2), eigvals), axis=2)
+            l2_dists = squared_l2_dists**0.5
+            baseline_means.append(jnp.mean(l2_dists, axis=1))
+            baseline_vars.append(jnp.var(l2_dists, axis=1))
+
+        return np.array(jnp.concatenate(baseline_means, axis=0)), np.array(jnp.concatenate(baseline_vars, axis=0))

--- a/src/scvi_v2/_module.py
+++ b/src/scvi_v2/_module.py
@@ -43,7 +43,7 @@ class _DecoderZX(nn.Module):
         z_drop = nn.Dropout(self.dropout_rate)(jax.lax.stop_gradient(z), deterministic=not training)
         batch_covariate = batch_covariate.astype(int).flatten()
         # cells by n_out by n_latent (n_in)
-        A_b = nn.Embed(self.n_batch, self.n_out * self.n_in, embedding_init=_normal_initializer)(
+        A_b = nn.Embed(self.n_batch, self.n_out * self.n_in, embedding_init=_normal_initializer, name="A_b")(
             batch_covariate
         ).reshape(batch_covariate.shape[0], self.n_out, self.n_in)
         if z_drop.ndim == 3:
@@ -74,7 +74,7 @@ class _DecoderUZ(nn.Module):
         u_drop = nn.Dropout(self.dropout_rate)(jax.lax.stop_gradient(u), deterministic=not training)
         sample_covariate = sample_covariate.astype(int).flatten()
         # cells by n_latent by n_latent
-        A_s = nn.Embed(self.n_sample, self.n_latent * self.n_latent, embedding_init=_normal_initializer)(
+        A_s = nn.Embed(self.n_sample, self.n_latent * self.n_latent, embedding_init=_normal_initializer, name="A_s")(
             sample_covariate
         ).reshape(sample_covariate.shape[0], self.n_latent, self.n_latent)
         if u_drop.ndim == 3:
@@ -204,7 +204,9 @@ class MrVAE(JaxBaseModuleClass):
     def generative(self, z, library, batch_index, continuous_covs):
         """Generative model."""
         library_exp = jnp.exp(library)
-        px = self.px(z, batch_index, size_factor=library_exp, continuous_covariates=continuous_covs, training=self.training)
+        px = self.px(
+            z, batch_index, size_factor=library_exp, continuous_covariates=continuous_covs, training=self.training
+        )
         h = px.mean / library_exp
 
         pu = dist.Normal(0, 1)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,3 +1,5 @@
+import pdb
+
 import numpy as np
 from scvi.data import synthetic_iid
 
@@ -19,14 +21,14 @@ def test_mrvi():
     assert model.get_latent_representation().shape == (adata.shape[0], 10)
     local_vmap = model.get_local_sample_representation()
     assert local_vmap.shape == (adata.shape[0], 15, 10)
-    local_dist_vmap = model.get_local_sample_representation(return_distances=True)
+    local_dist_vmap = model.get_local_sample_distances()
     assert local_dist_vmap.shape == (
         adata.shape[0],
         15,
         15,
     )
     local_map = model.get_local_sample_representation(use_vmap=False)
-    local_dist_map = model.get_local_sample_representation(return_distances=True, use_vmap=False)
+    local_dist_map = model.get_local_sample_distances(use_vmap=False)
     assert local_map.shape == (adata.shape[0], 15, 10)
     assert local_dist_map.shape == (
         adata.shape[0],
@@ -35,5 +37,13 @@ def test_mrvi():
     )
     assert np.allclose(local_map, local_vmap, atol=1e-6)
     assert np.allclose(local_dist_map, local_dist_vmap, atol=1e-6)
+
+    local_normalized_dists = model.get_local_sample_distances(normalize_distances=True)
+    assert local_normalized_dists.shape == (
+        adata.shape[0],
+        15,
+        15,
+    )
     # tests __repr__
     print(model)
+    pdb.set_trace()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,5 +1,3 @@
-import pdb
-
 import numpy as np
 from scvi.data import synthetic_iid
 
@@ -46,4 +44,3 @@ def test_mrvi():
     )
     # tests __repr__
     print(model)
-    pdb.set_trace()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -42,5 +42,6 @@ def test_mrvi():
         15,
         15,
     )
+    print(local_normalized_dists)
     # tests __repr__
     print(model)


### PR DESCRIPTION
Fixes #22 

This PR does the following:
- use xarray as the return type for both local sample representations and local sample distance
- splits up local sample distances as its own function
- implements a normalized distance metric which uses monte carlo samples to determine the mean and variance of the distribution of l2 distances between a pair of independent samples of z from the original sample. Then, the distances with other samples' z representations are z-scored and clipped to a minimum of 0.