### PR TITLE
Add back sparse and xarray deps, lower bound scvi-tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ urls.Documentation = "https://mrvi.readthedocs.io/"
 urls.Source = "https://github.com/YosefLab/mrvi"
 urls.Home-page = "https://github.com/YosefLab/mrvi"
 dependencies = [
-    "scvi-tools>=1.1.0rc2",
+    "scvi-tools[criticism]>=1.1.0",  # criticism for sparse and xarray
     "seaborn>=0.12.1",
     "statsmodels>=0.13.0",
 ]


### PR DESCRIPTION
Sets lower bound on scvi-tools to 1.1.0 and adds back sparse and xarray dependencies.